### PR TITLE
Add upstream remote to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,52 @@ Please be sure to review our [community statement and code of conduct](https://g
 
 Check out the [contributor docs](https://github.com/processing/p5.js/blob/main/contributor_docs/) for more in-depth details about contributing code, bug fixes, and documentation.
 
+# Quick Get Started For Developers
+
+If you want to work/contribute to p5.js'🌸 codebase as a developer, either directly for improving p5.js or for improving its sub-projects like [Friendly Error Systems](./friendly_error_system.md), you can follow the following steps:
+
+1. [Create a fork of p5.js.](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+2. [Clone your created fork to your computer.](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
+3. [Add upstream using the following command](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-repository-for-a-fork):
+
+  ```
+  git remote add upstream https://github.com/processing/p5.js
+  ```
+
+4. Make sure your machine has [NodeJs](https://nodejs.org/en/download) installed; check it with the following command:
+
+  ```
+  node -v
+  ```
+
+5. Install dependencies with:
+
+  ```
+  npm ci
+  ```
+
+6. Create a git branch of the `main` branch having a descriptive branch name using: 
+
+  ```
+  git checkout -b [branch_name]
+  ```
+
+7. As you start making changes to the codebase, frequently run the tests (it takes time, but it ensures that existing behaviors are not being broken).
+
+  ```
+  npm test
+  ```
+
+8. Add any unit tests if you are working on adding new features or feature enhancement.
+9. Once done, you can commit the changes and create a [Pull Request](#pull-requests).
+
+# Confirming Upstream Remote Addition
+
+To confirm that the upstream remote has been added, you can use the following command:
+
+```
+git remote -v
+```
+
+This will list all the remote repositories associated with your local repository. You should see an entry for `upstream` pointing to `https://github.com/processing/p5.js`.
+


### PR DESCRIPTION
Add instructions for adding upstream remote in `CONTRIBUTING.md`.

* Add a new section "Quick Get Started For Developers" with steps for setting up the development environment.
* Include a step to add the upstream remote using the command `git remote add upstream https://github.com/processing/p5.js`.
* Add a section "Confirming Upstream Remote Addition" to verify the upstream remote addition using `git remote -v`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/p5.js/pull/1?shareId=d2e97ebb-aa5e-470c-8d25-615c023c5dc3).